### PR TITLE
Add devhub v0.45.4

### DIFF
--- a/Casks/devhub.rb
+++ b/Casks/devhub.rb
@@ -1,0 +1,13 @@
+cask 'devhub' do
+  version '0.45.4'
+  sha256 'd92b27436f0d9ba4f767b6162e89c303637533a3e4bedac6ac2c2b1ce345df88'
+
+  url "https://github.com/devhubapp/devhub/releases/download/v#{version}/DevHub-#{version}.dmg"
+  appcast 'https://github.com/devhubapp/devhub/releases.atom'
+  name 'DevHub'
+  homepage 'https://github.com/devhubapp/devhub'
+
+  auto_updates true
+
+  app 'DevHub.app'
+end


### PR DESCRIPTION
Add devhub v0.45.4 

autoupdates true line has been added to this cask file as devhub is capable of auto updates.  This cask file will only be needed first time to install devhub, later it will update itself on its own